### PR TITLE
implementing contextual validation

### DIFF
--- a/spec/Speck.spec.js
+++ b/spec/Speck.spec.js
@@ -11,7 +11,9 @@ import {
   ChildrenEntity,
   FatherEntity,
   FatherWithObjectEntity,
-  ChildWithChildArray
+  ChildWithChildArray,
+  FakeEntityWithExcludeContext,
+  FakeEntityWithIncludeContext
 } from './fixtures/fakerClasses';
 
 describe('Speck', function (){
@@ -230,6 +232,36 @@ describe('Speck', function (){
       expect(childWithChildArray.constructor).toBe(ChildWithChildArray);
       expect(childWithChildArray.children[0].constructor).toBe(ChildWithChildArray);
     });
+  });
 
+  describe('Contextual validation', function (){
+
+    it('it should set contexts excluded', () => {
+      const fakeEntityWithContext = new FakeEntityWithExcludeContext({
+        name: 'Node1'
+      });
+
+      const contextValidated = fakeEntityWithContext.validateContext('create');
+
+      expect(fakeEntityWithContext.constructor).toBe(FakeEntityWithExcludeContext);
+      expect(contextValidated.id).toBeUndefined();
+      expect(contextValidated.requiredProp1).not.toBeUndefined();
+      expect(contextValidated.requiredProp2).not.toBeUndefined();
+      expect(contextValidated.requiredProp3).toBeUndefined();
+    });
+
+    it('it should set contexts include', () => {
+      const fakeEntityWithContext = new FakeEntityWithIncludeContext({
+        name: 'Node1'
+      });
+
+      const contextValidated = fakeEntityWithContext.validateContext('create');
+
+      expect(fakeEntityWithContext.constructor).toBe(FakeEntityWithIncludeContext);
+      expect(contextValidated.id).toBeUndefined();
+      expect(contextValidated.requiredProp1).not.toBeUndefined();
+      expect(contextValidated.requiredProp2).not.toBeUndefined();
+      expect(contextValidated.requiredProp3).toBeUndefined();
+    });
   });
 });

--- a/spec/fixtures/fakerClasses.js
+++ b/spec/fixtures/fakerClasses.js
@@ -106,6 +106,32 @@ class ChildWithChildArray extends Speck {
     }
 }
 
+class FakeEntityWithExcludeContext extends Speck {
+    static SCHEMA = {
+        id: PropTypes.number.isRequired,
+        requiredProp1: PropTypes.number.isRequired,
+        requiredProp2: PropTypes.number.isRequired,
+        requiredProp3: PropTypes.number.isRequired
+    }
+
+    static CONTEXTS = {
+      create: { exclude: [ 'id', 'requiredProp3' ] },
+      edit: { exclude: [ 'id', 'requiredProp2' ] }
+    }
+}
+
+class FakeEntityWithIncludeContext extends Speck {
+    static SCHEMA = {
+        id: PropTypes.number.isRequired,
+        requiredProp1: PropTypes.number.isRequired,
+        requiredProp2: PropTypes.number.isRequired,
+        requiredProp3: PropTypes.number.isRequired
+    }
+
+    static CONTEXTS = {
+      create: { include: [ 'requiredProp1', 'requiredProp2' ] }
+    }
+}
 
 exports.defaultField = defaultField;
 exports.defaultValue = defaultValue;
@@ -117,3 +143,5 @@ exports.ChildrenEntity = ChildrenEntity;
 exports.FatherEntity = FatherEntity;
 exports.FatherWithObjectEntity = FatherWithObjectEntity;
 exports.ChildWithChildArray = ChildWithChildArray;
+exports.FakeEntityWithExcludeContext = FakeEntityWithExcludeContext;
+exports.FakeEntityWithIncludeContext = FakeEntityWithIncludeContext;

--- a/src/Speck.js
+++ b/src/Speck.js
@@ -21,6 +21,11 @@ class Speck {
       enumerable: false
     });
 
+    Object.defineProperty(this, 'contexts', {
+      value: this.constructor.CONTEXTS,
+      enumerable: false
+    });
+
     Object.defineProperty(this, 'childrenEntities', {
       value: Object.keys(this.constructor.SCHEMA).filter((field) => !!this.constructor.SCHEMA[field].type),
       enumerable: false
@@ -137,6 +142,29 @@ class Speck {
     return errors;
   }
 
+  validateContext(context){
+    if(!this.contexts[context]) return this.errors;
+
+    let validation;
+    if(this.contexts[context].exclude && Object.keys(this.contexts[context].exclude).length > 0){
+      validation = (error)=>{
+        return this.contexts[context].exclude.find(exclude => exclude === error) === undefined;
+      };
+    }
+
+    if(this.contexts[context].include && Object.keys(this.contexts[context].include).length > 0){
+      validation = (error)=>{
+        return this.contexts[context].include.find(include => include === error) !== undefined;
+      };
+    }
+
+    const errors = Object.keys(this.errors).filter(validation);
+
+    return errors.reduce((acc,e)=>{
+      acc[e] = this.errors[e];
+      return acc;
+    },{});
+  }
 }
 
 Speck.SpeckCollection = SpeckCollection;


### PR DESCRIPTION
Implemeting contextual validation.

**Using**
```javascript
class FakeEntityWithIncludeContext extends Speck {
    static SCHEMA = {
        id: PropTypes.number.isRequired,
        requiredProp1: PropTypes.number.isRequired,
        requiredProp2: PropTypes.number.isRequired,
        requiredProp3: PropTypes.number.isRequired
    }

    static CONTEXTS = {
      create: { include: [ 'requiredProp1', 'requiredProp2' ] },
      edit: { exclude: [ 'requiredProp3' ] },
    }
}
```
Each context (create and edit in example above), could have _include_ property OR  _exclude_, the _include_ property receives the properties that will be validated in this context,
and the _exclude_ property represents the properties that will be ignored on validation.

In the example, the create context, will only check the 'requiredProp1' and 'requiredProp2'  fields, and the edit context will check 'requiredProp1', 'requiredProp2'  and 'id' properties.

You **can't** combine include and exclude in the same context definition
