### PR TITLE
Fix validateContext method

### DIFF
--- a/src/Speck.js
+++ b/src/Speck.js
@@ -164,6 +164,7 @@ class Speck {
       Object.keys(this.contexts[context].fields).forEach((field) => {
         const result = this.contexts[context].fields[field](this, field, this.constructor.name);
         if(result) contextErrors[field] = {errors: result};
+        else delete contextErrors[field];
       });
     }
 

--- a/src/Speck.js
+++ b/src/Speck.js
@@ -164,7 +164,6 @@ class Speck {
       Object.keys(this.contexts[context].fields).forEach((field) => {
         const result = this.contexts[context].fields[field](this, field, this.constructor.name);
         if(result) contextErrors[field] = {errors: result};
-        else contextErrors[field] = undefined;
       });
     }
 


### PR DESCRIPTION
When I call the method, he returned `{ property1: undefined, property2: { error: {...}} }`.
Now, if not found this property on fields, he not add this property on return. 
Eg.: `{ property2: { error: {...}} }`
