### PR TITLE
added toJSONByContext() on Speck

### DIFF
--- a/lib/Speck.js
+++ b/lib/Speck.js
@@ -167,6 +167,28 @@ var Speck = function () {
       return JSON.parse(JSON.stringify(rawData));
     }
   }, {
+    key: 'toJSONbyContext',
+    value: function toJSONbyContext(context) {
+      if (!(0, _lodash.get)(this.contexts, context)) return this.errors;
+
+      var contextOperator = (0, _lodash.first)(Object.keys(this.contexts[context]));
+
+      var operation = {
+        include: function include(entityObj, _include) {
+          return (0, _lodash.intersection)(Object.keys(entityObj), _include).reduce(function (parsedObj, key) {
+            return _extends({}, parsedObj, _defineProperty({}, key, entityObj[key]));
+          }, {});
+        },
+        exclude: function exclude(entityObj, _exclude) {
+          return (0, _lodash.difference)(Object.keys(entityObj), _exclude).reduce(function (parsedObj, key) {
+            return _extends({}, parsedObj, _defineProperty({}, key, entityObj[key]));
+          }, {});
+        }
+      };
+
+      return contextOperator !== undefined ? operation[contextOperator](this.toJSON(), this.contexts[context][contextOperator]) : this.toJSON();
+    }
+  }, {
     key: 'getErrors',
     value: function getErrors() {
       var errors = _extends({}, this._validate());

--- a/spec/Speck.spec.js
+++ b/spec/Speck.spec.js
@@ -196,7 +196,7 @@ describe('Speck', () => {
         requiredProp3: 1
       });
 
-      expect(fakeEntityWithContext.toJSONByContext('create')).to.deep.equal({
+      expect(fakeEntityWithContext.toJSONContext('create')).to.deep.equal({
         requiredProp1: 1,
         requiredProp2: 1
       });
@@ -211,15 +211,21 @@ describe('Speck', () => {
         requiredProp3: 1
       });
 
-      expect(fakeEntityWithContext.toJSONByContext('create')).to.deep.equal({
+      expect(fakeEntityWithContext.toJSONContext('create')).to.deep.equal({
         requiredProp1: 1,
         requiredProp2: 1
       });
 
-      expect(fakeEntityWithContext.toJSONByContext('edit')).to.deep.equal({
+      expect(fakeEntityWithContext.toJSONContext('edit')).to.deep.equal({
         requiredProp1: 1,
         requiredProp3: 1
       });
+    })
+
+    it('Should return Errors on invalid Context', () => {
+      const entity = new ProductEntity({ foo: 'bar' });
+
+      expect(entity.toJSONContext.bind(entity, 'noValidContext')).to.throw(Error, /InvalidContext/);
     })
   })
 

--- a/spec/Speck.spec.js
+++ b/spec/Speck.spec.js
@@ -137,11 +137,11 @@ describe('Speck', () => {
           isDefault: true
         }]
       });
-      
+
       expect(elementEntity.elements[0].constructor).to.equal(ProductEntity);
       expect(elementEntity.elements[1].constructor).to.equal(FakeEntityWithBoolean);
   });
-    
+
     it('builds automatically child entities of array', () => {
       const father = new FatherEntity({
         children: [
@@ -185,6 +185,43 @@ describe('Speck', () => {
       });
     });
   });
+
+  describe('toJSONbyContext', () => {
+    it('cleans data on including context', () => {
+      const fakeEntityWithContext = new FakeEntityWithIncludeContext({
+        fakeAttribute: 'should not come',
+        id: 1,
+        requiredProp1: 1,
+        requiredProp2: 1,
+        requiredProp3: 1
+      });
+
+      expect(fakeEntityWithContext.toJSONByContext('create')).to.deep.equal({
+        requiredProp1: 1,
+        requiredProp2: 1
+      });
+    })
+
+    it('cleans data on excluding context', () => {
+      const fakeEntityWithContext = new FakeEntityWithExcludeContext({
+        fakeAttribute: 'should not come',
+        id: 1,
+        requiredProp1: 1,
+        requiredProp2: 1,
+        requiredProp3: 1
+      });
+
+      expect(fakeEntityWithContext.toJSONByContext('create')).to.deep.equal({
+        requiredProp1: 1,
+        requiredProp2: 1
+      });
+
+      expect(fakeEntityWithContext.toJSONByContext('edit')).to.deep.equal({
+        requiredProp1: 1,
+        requiredProp3: 1
+      });
+    })
+  })
 
   describe('validateContext', () => {
     it('sets contexts excluded', () => {

--- a/src/Speck.js
+++ b/src/Speck.js
@@ -134,10 +134,10 @@ class Speck {
     return JSON.parse(JSON.stringify(rawData));
   }
 
-  toJSONByContext(context) {
-    if(!get(this.contexts, context)) return this.errors;
+  toJSONContext(context) {
+    const contextOperator = first(Object.keys(get(this.contexts, context) || []))
 
-    const contextOperator = first(Object.keys(this.contexts[context]))
+    if(contextOperator === undefined) throw new Error('InvalidContext')
 
     const operation = {
       include: (entityObj, include) => {
@@ -150,9 +150,7 @@ class Speck {
       }
     }
 
-    return (contextOperator !== undefined)
-      ? operation[contextOperator](this.toJSON(), this.contexts[context][contextOperator])
-      : this.errors
+    return operation[contextOperator](this.toJSON(), this.contexts[context][contextOperator])
   }
 
   getErrors() {


### PR DESCRIPTION
Hello Guys! 😀

In my currently project, I need to execute a `toJSON()` but by passing a context.
My use case is:
 - Instantiate an Entity
 - Pass this Entity around doing some other stuff
 - New attributes are added
 - When returning, I want to resolve to a JSON, but with only specific attributes

A Simple example:
``` javascript
class User extends Speck {
  static SCHEMA = {
    email: PropTypes.string.isRequired,
    password: PropTypes.string.isRequired,
    planet: PropTypes.string.isRequired,
  }

  static CONTEXTS = {
     login: { exclude: ['planet'] },
     astronaut: { include: ['planet'] },
  }
}

```
``` javascript

const user = new User({ email, password });
if (user.validateContext('login')) {
  sendUserToMars(user);
  return user.toJSONByContext('astronaut')  // { planet: 'Mars' }
} 

```

Thanks!